### PR TITLE
Change default control plane operator image

### DIFF
--- a/assets/control-plane-operator/cp-operator-deployment.yaml
+++ b/assets/control-plane-operator/cp-operator-deployment.yaml
@@ -80,7 +80,7 @@ spec:
         - name: KUBERNETES_VERSION
           value: {{ version "kubernetes" }}
         command:
-        - "/usr/bin/control-plane-operator"
+        - "/usr/bin/hypershift-operator"
         - "--initial-ca-file=/etc/kubernetes/config/initial-ca.crt"
         - "--target-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig"
         - "--namespace"

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -699,7 +699,7 @@ spec:
         - name: KUBERNETES_VERSION
           value: {{ version "kubernetes" }}
         command:
-        - "/usr/bin/control-plane-operator"
+        - "/usr/bin/hypershift-operator"
         - "--initial-ca-file=/etc/kubernetes/config/initial-ca.crt"
         - "--target-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig"
         - "--namespace"

--- a/pkg/aws/install.go
+++ b/pkg/aws/install.go
@@ -52,7 +52,7 @@ const (
 	externalOauthPort     = 8443
 	workerMachineSetCount = 3
 
-	defaultControlPlaneOperatorImage = "registry.svc.ci.openshift.org/hypershift-toolkit/hypershift-4.4:control-plane-operator"
+	defaultControlPlaneOperatorImage = "quay.io/hypershift/hypershift-operator:latest"
 
 	DefaultAPIServerIPAddress = "172.20.0.1"
 )
@@ -389,16 +389,6 @@ func InstallCluster(name, releaseImage, dhParamsFile string, waitForReady bool) 
 	params.RouterNodePortHTTPS = fmt.Sprintf("%d", routerNodePortHTTPS)
 	params.RouterServiceType = "NodePort"
 	params.Replicas = "1"
-	params.ControlPlaneOperatorControllers = []string{
-		"controller-manager-ca",
-		"auto-approver",
-		"kubeadmin-password",
-		"cluster-operator",
-		"cluster-version",
-		"kubelet-serving-ca",
-		"openshift-apiserver",
-		"openshift-controller-manager",
-	}
 	cpOperatorImage := os.Getenv("CONTROL_PLANE_OPERATOR_IMAGE_OVERRIDE")
 	if cpOperatorImage == "" {
 		params.ControlPlaneOperatorImage = defaultControlPlaneOperatorImage


### PR DESCRIPTION
Use the new operator image built from github.com/openshift-hive/hypershift-operator by default.
No need to specify controllers, since now it starts all controllers by default.