### PR TITLE
Uninstall: absent IngressController should not be an error

### DIFF
--- a/pkg/installer/uninstall.go
+++ b/pkg/installer/uninstall.go
@@ -80,5 +80,9 @@ func removeWorkerMachineset(client dynamic.Interface, infraName, namespace strin
 }
 
 func removeIngressController(client operatorclient.Interface, name string) error {
-	return client.OperatorV1().IngressControllers(ingressOperatorNamespace).Delete(name, &metav1.DeleteOptions{})
+	err := client.OperatorV1().IngressControllers(ingressOperatorNamespace).Delete(name, &metav1.DeleteOptions{})
+	if err == nil || errors.IsNotFound(err) {
+		return nil
+	}
+	return err
 }


### PR DESCRIPTION
On uninstall avoid reporting an error if the ingress controller is no longer there.