### PR TITLE
Remove duplicate entries of bin files in ignition

### DIFF
--- a/assets/ignition/units/apiserver-ip.service
+++ b/assets/ignition/units/apiserver-ip.service
@@ -5,8 +5,8 @@ After=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart=/bin/bash /usr/local/bin/setup-apiserver-ip.sh
-ExecStop=/bin/bash /usr/local/bin/teardown-apiserver-ip.sh
+ExecStart=/usr/local/bin/setup-apiserver-ip.sh
+ExecStop=/usr/local/bin/teardown-apiserver-ip.sh
 RemainAfterExit=yes
 
 [Install]

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -1502,8 +1502,8 @@ After=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart=/bin/bash /usr/local/bin/setup-apiserver-ip.sh
-ExecStop=/bin/bash /usr/local/bin/teardown-apiserver-ip.sh
+ExecStart=/usr/local/bin/setup-apiserver-ip.sh
+ExecStop=/usr/local/bin/teardown-apiserver-ip.sh
 RemainAfterExit=yes
 
 [Install]

--- a/pkg/ignition/generate.go
+++ b/pkg/ignition/generate.go
@@ -87,7 +87,6 @@ func addAssetFiles(cfg *igntypes.Config, params *api.ClusterParams, prefix strin
 		} else {
 			addFileBytes(cfg, data, destPath, 0644)
 		}
-		addFileBytes(cfg, data, destPath, 0644)
 		return nil
 	}
 	files, err := assets.AssetDir(assetPath)


### PR DESCRIPTION
Scripts in /usr/local/bin were added to the bootstrap ignition twice,
resulting in the ones copied over to the nodes with 644 permission,
instead of expected 755. This commit ensures single entry is present in
the ignition file, with 755 mode

Since the scripts did not have executable permissions, the units
supposed to run the scripts needed to have explicit target for bash.
This is no longer needed, hence removed