### PR TITLE
openvpn docker build should fail when yum install fails

### DIFF
--- a/assets/openvpn/Dockerfile
+++ b/assets/openvpn/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.access.redhat.com/ubi7/ubi
-RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm; \
-    yum install -y openvpn; \
+RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
+    yum install -y openvpn && \
     yum clean all
 CMD ["/usr/sbin/openvpn"]

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -3864,8 +3864,8 @@ func openshiftControllerManagerOpenshiftControllerManagerServiceCaYaml() (*asset
 }
 
 var _openvpnDockerfile = []byte(`FROM registry.access.redhat.com/ubi7/ubi
-RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm; \
-    yum install -y openvpn; \
+RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
+    yum install -y openvpn && \
     yum clean all
 CMD ["/usr/sbin/openvpn"]
 `)


### PR DESCRIPTION
Current Dockerfile allows `yum install` to fail but still finishes a successful build.