### PR TITLE
Add dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13 AS builder
+
+WORKDIR /go/src/github.com/openshift-hive/hypershift-installer
+COPY . .
+RUN make
+
+FROM registry.svc.ci.openshift.org/origin/4.1:base
+COPY --from=builder /go/src/github.com/openshift-hive/hypershift-installer/bin/hypershift-installer /bin/hypershift-installer
+RUN mkdir /output && chown 1000:1000 /output
+USER 1000:1000
+ENV PATH /bin
+ENV HOME /output
+WORKDIR /output
+ENTRYPOINT ["/bin/hypershift-installer"]

--- a/hack/update-bindata.sh
+++ b/hack/update-bindata.sh
@@ -8,7 +8,7 @@ OUTPUT_FILE="${OUTPUT_FILE:-./pkg/assets/bindata.go}"
 cd "${SRC_DIR}"
 
 # ensure go-bindata
-GOBIN=${SRC_DIR}/bin go install github.com/jteeuwen/go-bindata/go-bindata
+GOBIN=${SRC_DIR}/bin GO111MODULE=off go get github.com/jteeuwen/go-bindata/go-bindata
 
 # go-bindata generates code assets from the yaml we want to deploy by the operator.
 "./bin/go-bindata" \


### PR DESCRIPTION
This is a first step for integrating hypershift with hive. I will use this in hive to pull the hypershift-installer binary
I'm not sure where this will be pushed though. @csrwng is it possible to push it to like an openshift docker organization or similar so that its trusted?