### PR TITLE
Allow specifying platform type for install

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,14 @@ The hypershift installer is a program for running OpenShift 4.x in a hyperscale 
 * Setup your KUBECONFIG to point to the management cluster
 * Run `./bin/hypershift-installer destroy cluster NAME` where NAME is the name you gave your
   cluster when creating the `install-config.yaml`.
+
+### Environment Variables used by the Installer
+* `CONTROL_PLANE_OPERATOR_IMAGE_OVERRIDE` - Override for the control plane operator image. Defaults to
+  `registry.svc.ci.openshift.org/hypershift-toolkit/ibm-roks-{MAJOR}.{MINOR}:control-plane-operator`.
+* `HYPERSHIFT_OPERATOR_IMAGE_OVERRIDE` - Override for the hypershift operator image. Defaults to 
+  `quay.io/hypershift/hypershift-operator:latest`.
+* `DH_PARAMS` - file containing Diffie-Hellman parameters for VPN server. By default this file is generated and placed
+   in `install-files/pki/openvpn-dh.pem`.
+* `KUBECONFIG` - Kubeconfig pointing to host cluster. If not set, the `~/.kube/config` file is used.
+* `PLATFORM_TYPE` - Platform type for child cluster's Infrastructure config. If not specified, it is set to
+  `None`.

--- a/pkg/installer/install.go
+++ b/pkg/installer/install.go
@@ -253,6 +253,9 @@ func (o *CreateClusterOpts) Run() error {
 		return fmt.Errorf("failed to create temporary pull secret file: %v", err)
 	}
 	releaseVersion, err := render.ReleaseVersion(releaseImage, pullSecretFile)
+	if err != nil {
+		return fmt.Errorf("cannot obtain release version: %v", err)
+	}
 	version, err := semver.Parse(releaseVersion)
 	if err != nil {
 		return fmt.Errorf("cannot parse release version (%s): %v", releaseVersion, err)
@@ -294,6 +297,9 @@ func (o *CreateClusterOpts) Run() error {
 		params.HypershiftOperatorImage = hypershiftOperatorImage
 	}
 	params.HypershiftOperatorControllers = []string{"route-sync", "auto-approver", "kubeadmin-password", "node"}
+	if platformType := os.Getenv("PLATFORM_TYPE"); platformType != "" {
+		params.PlatformType = platformType
+	}
 
 	pkiDir := filepath.Join(workingDir, "pki")
 	if err = os.MkdirAll(pkiDir, 0755); err != nil {


### PR DESCRIPTION
Also adds section to README to document the environment variables
used by the hypershift installer.