### PR TITLE
Update mcs bootstrap container arguments

### DIFF
--- a/assets/machine-config-server/machine-config-server-deployment.yaml
+++ b/assets/machine-config-server/machine-config-server-deployment.yaml
@@ -46,13 +46,13 @@ spec:
         - |-
           mkdir -p /mcc-manifests/bootstrap/manifests
           mkdir -p /mcc-manifests/manifests
-          exec machine-config-operator bootstrap \
+          exec machine-config-operator bootstrap \{{ if lessthan_version "4.6.0" }}
           --etcd-ca=/assets/manifests/root-ca.crt \
           --etcd-metric-ca=/assets/manifests/root-ca.crt \
+          --etcd-image={{ imageFor "etcd" }} \
+          --kube-client-agent-image={{ imageFor "kube-client-agent" }} \{{ end }}
           --root-ca=/assets/manifests/root-ca.crt \
           --kube-ca=/assets/manifests/combined-ca.crt \
-          --etcd-image={{ imageFor "etcd" }} \
-          --kube-client-agent-image={{ imageFor "kube-client-agent" }} \
           --machine-config-operator-image={{ imageFor "machine-config-operator" }} \
           --machine-config-oscontent-image={{ imageFor "machine-os-content" }} \
           --infra-image={{ imageFor "pod" }} \

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -2087,13 +2087,13 @@ spec:
         - |-
           mkdir -p /mcc-manifests/bootstrap/manifests
           mkdir -p /mcc-manifests/manifests
-          exec machine-config-operator bootstrap \
+          exec machine-config-operator bootstrap \{{ if lessthan_version "4.6.0" }}
           --etcd-ca=/assets/manifests/root-ca.crt \
           --etcd-metric-ca=/assets/manifests/root-ca.crt \
+          --etcd-image={{ imageFor "etcd" }} \
+          --kube-client-agent-image={{ imageFor "kube-client-agent" }} \{{ end }}
           --root-ca=/assets/manifests/root-ca.crt \
           --kube-ca=/assets/manifests/combined-ca.crt \
-          --etcd-image={{ imageFor "etcd" }} \
-          --kube-client-agent-image={{ imageFor "kube-client-agent" }} \
           --machine-config-operator-image={{ imageFor "machine-config-operator" }} \
           --machine-config-oscontent-image={{ imageFor "machine-os-content" }} \
           --infra-image={{ imageFor "pod" }} \

--- a/pkg/render/manifests.go
+++ b/pkg/render/manifests.go
@@ -58,6 +58,8 @@ func newClusterManifestContext(images, versions map[string]string, params interf
 		"pki":               pkiFunc(pkiDir),
 		"include_pki":       includePKIFunc(pkiDir),
 		"pullSecretBase64":  pullSecretBase64(pullSecretFile),
+		"atleast_version":   atLeastVersionFunc(versions),
+		"lessthan_version":  lessThanVersionFunc(versions),
 	})
 	return ctx
 }


### PR DESCRIPTION
Removes container arguments that are no longer used in 4.6