### PR TITLE
kube-apiserver: fix missing secret reference

### DIFF
--- a/assets/kube-apiserver/kube-apiserver-secret.yaml
+++ b/assets/kube-apiserver/kube-apiserver-secret.yaml
@@ -11,3 +11,4 @@ data:
   etcd-client.key: {{ pki "etcd-client.key" }}
   proxy-client.crt: {{ pki "kube-apiserver-aggregator-proxy-client.crt" }}
   proxy-client.key: {{ pki "kube-apiserver-aggregator-proxy-client.key" }}
+  service-account.key: {{ pki "service-account.key" }}

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -1087,6 +1087,7 @@ data:
   etcd-client.key: {{ pki "etcd-client.key" }}
   proxy-client.crt: {{ pki "kube-apiserver-aggregator-proxy-client.crt" }}
   proxy-client.key: {{ pki "kube-apiserver-aggregator-proxy-client.key" }}
+  service-account.key: {{ pki "service-account.key" }}
 `)
 
 func kubeApiserverKubeApiserverSecretYamlBytes() ([]byte, error) {


### PR DESCRIPTION
Before this patch, kube-apiserver would crash because of the missing
secret this patch introduces.